### PR TITLE
Add alias slash commands

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,6 @@ jobs:
       env:
         DISCORDTOKEN: ${{ secrets.DISCORDTOKEN }}
       run: nimble --deepcopy:on --gc:${{ matrix.gc }} test
+
+    - name: Check doc examples
+      run: nimble doc --deepcopy:on --gc:${{ matrix.gc }} --project src/dimscmd.nim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
 
-    name: Nim ${{ matrix.nim }}
+    name: Nim ${{ matrix.nim }} ${{ matrix.gc }}
     steps:
     - name: Cache choosenim
       id: cache-choosenim
@@ -37,4 +37,4 @@ jobs:
       run: nimble --deepcopy:on --gc:${{ matrix.gc }} test
 
     - name: Check doc examples
-      run: nimble doc --deepcopy:on --gc:${{ matrix.gc }} --project src/dimscmd.nim
+      run: nimble doc --deepcopy:on --threads:off --gc:${{ matrix.gc }} --project src/dimscmd.nim

--- a/src/dimscmd.nim
+++ b/src/dimscmd.nim
@@ -174,6 +174,7 @@ macro addCommand(router: untyped, name: static[string], handler: untyped, kind: 
         cmdVariable = genSym(kind = nskVar, ident = "command")
 
     let description = handler.getDoc()
+      
     if kind == ctSlashCommand and description.isEmptyOrWhitespace:
       "Must provide a description has a doc comment".error(handler)
       
@@ -315,6 +316,7 @@ proc addAlias*(group: CommandGroup, commandName: string, aliases: openArray[stri
     cmd.chatCommands.addAlias("ping", ["pi"])
     cmd.slashCommands.addAlias("joke", ["funnyword"])
   #==#
+  # TODO: link to docs about requirements
   let commandKey = commandName.getWords()
   if group.has(commandKey):
     var command = group.get(commandKey)

--- a/src/dimscmd/commandOptions.nim
+++ b/src/dimscmd/commandOptions.nim
@@ -59,7 +59,7 @@ proc toOption(group: CommandGroup): ApplicationCommandOption =
         let cmd = group.command
         result = ApplicationCommandOption(
             kind: acotSubCommand,
-            name: cmd.name.leafName(),
+            name: group.name,
             description: cmd.description,
             options: cmd.parameters.toOptions(),
         )

--- a/src/dimscmd/common.nim
+++ b/src/dimscmd/common.nim
@@ -100,11 +100,13 @@ func newGroup*(cmd: Command): CommandGroup =
         command: cmd
     )
 
-func print*(group: CommandGroup, depth = 1) =
-    for child in group.children:
-        debugEcho child.name.indent(depth) & (if child.isLeaf: " - " else: "")
-        if not child.isLeaf:
-            child.print(depth + 1)
+proc print*(group: CommandGroup, depth = 1) =
+  ## Used for debugging, prints out the tree structure of the group.
+  ## If the node is a handler then it is suffixed with -
+  for child in group.children:
+    echo child.name.indent(depth) & (if child.isLeaf: " - " else: "")
+    if not child.isLeaf:
+      child.print(depth + 1)
 
 func flatten*(group: CommandGroup, name = ""): seq[Command] =
     ## Flattens a group into a sequence of tuples
@@ -188,15 +190,14 @@ func get*(root: CommandGroup, key: openarray[string]): Command =
         raise newException(KeyError, fmt"{key} does not match a leaf node")
 
 func has*(root: CommandGroup, key: openarray[string]): bool =
-    ## Returns true if the key points to a command or a command group
-    var currentNode = root
-    result = true # We assume by default that the key exists
-    currentNode.traverseTree(key):
-        # And set it to false if proved otherwise
-        if not found:
-            result = false
-            break
-
+  ## Returns true if the key points to a command or a command group
+  var currentNode = root
+  result = true # We assume by default that the key exists
+  currentNode.traverseTree(key):
+    # And return false if proved otherwise
+    if not found:
+      return false
+      
 func mapAltPath*(root: CommandGroup, a, b: openarray[string]) =
     ## Makes b also point to a
     ## Checks for ambiguity before adding

--- a/src/dimscmd/interactionUtils.nim
+++ b/src/dimscmd/interactionUtils.nim
@@ -60,14 +60,14 @@ template getOption(
         opts: Table[string, ApplicationCommandInteractionDataOption],
         kind: typedesc,
         key: string,
-        prop: untyped): untyped {.dirty.} =
+        prop: untyped): Option[kind] {.dirty.} =
     bind hasKey
     bind `[]`
     block:
-        if opts.hasKey(key):
-            some kind(opts[key].prop)
-        else:
-            none kind
+      if opts.hasKey(key):
+        some kind(opts[key].prop)
+      else:
+        none kind
 
 # Basic types
 proc get*(scnr; kind: typedesc[int], key: string):    Option[int]    = scnr.data.getOption(int, key, ival)

--- a/src/dimscmd/utils.nim
+++ b/src/dimscmd/utils.nim
@@ -28,12 +28,12 @@ macro matchIdent*(id: string, body: untyped): untyped =
         if node[^1].kind == nnkElse:
             result.add node[^1]
 
-proc nextWord*(input: string, output: var string, start = 0): int =
+func nextWord*(input: string, output: var string, start = 0): int =
     ## Gets the next word after `start` in the string and puts it in `output`
     result += input.parseUntil(output, Whitespace, start = start)
     result += input.skipWhitespace(start = start + result)
 
-proc getWords*(input: string): seq[string] =
+func getWords*(input: string): seq[string] =
     ## Splits the input string into each word
     ## Handles multple spaces
     var i = 0
@@ -45,7 +45,7 @@ proc getWords*(input: string): seq[string] =
         i += input.nextWord(newWord, start = i)
         result &= newWord
 
-proc leafName*(input: string): string =
+func leafName*(input: string): string =
     ## Returns the last word in a sentence
     # Start at the final character and continue adding
     var index = len(input) - 1
@@ -53,4 +53,23 @@ proc leafName*(input: string): string =
         result.insert($input[index], 0)
         dec index
 
-
+func checkSlashName*(name: string): bool =
+  ## Checks if a slash command name is valid.
+  ## A valid name must meet these criteria
+  ## 
+  ## * Length is in between 1 and 32 (inclusive)
+  ## * Only contains characters in the set `{'a'..'z', '-', '_'}`
+  runnableExamples:
+    assert not checkSlashName "calc +"
+    assert checkSlashName "calc plus"
+    assert not checkSlashName "Calc plus"
+    assert not checkSlashName "calc a"
+  #==#
+  result = true
+  for word in name.getWords():
+    if word.len notin 3..32:
+      return false
+    for character in word:
+      if character notin {'a'..'z', '-', '_'}:
+        return false
+      

--- a/tests/testSlash.nim
+++ b/tests/testSlash.nim
@@ -121,7 +121,7 @@ cmd.addSlash("calc times") do (a: int, b: int):
   ## Multiples two values
   latestMessage = $(a * b)
 
-cmd.addSlashAlias("calc add", ["calc plus", "calc +"])
+cmd.addSlashAlias("calc add", ["calc plus", "calc addition"])
 
 proc onReady(s: Shard, r: Ready) {.event(discord).} =
     await cmd.registerCommands()
@@ -252,7 +252,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
         check waitFor cmd.handleInteraction(nil, interaction)
         check latestMessage == "66"
       block:
-        let interaction = newAddCommand(1, 2, "+")
+        let interaction = newAddCommand(1, 2, "addition")
         check waitFor cmd.handleInteraction(nil, interaction)
         check latestMessage == "3"
         

--- a/tests/testSlash.nim
+++ b/tests/testSlash.nim
@@ -124,6 +124,7 @@ cmd.addSlash("calc times") do (a: int, b: int):
 cmd.addSlashAlias("calc add", ["calc plus", "calc +"])
 
 proc onReady(s: Shard, r: Ready) {.event(discord).} =
+    await cmd.registerCommands()
     test "Basic":
         sendInteraction("basic", %* [])
         check latestMessage == "hello world"

--- a/tests/testSlash.nim
+++ b/tests/testSlash.nim
@@ -215,12 +215,12 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
               "type": 1,
               "options": [
                 {
-                  "value": 10,
+                  "value": a,
                   "type": 4,
                   "name": "a"
                 },
                 {
-                  "value": 12,
+                  "value": b,
                   "type": 4,
                   "name": "b"
                 }


### PR DESCRIPTION
Allows you to alias slash commands (Implements #15)

```nim
# Aliases "pi" and "pingy" to "ping" 
cmd.addSlashAlias("ping", ["pingy", "pi"])
```

Also improved the CI to check that commands registered properly since I found out it doesn't check