### PR TITLE
Allow different cases in parameters

### DIFF
--- a/src/dimscmd/commandOptions.nim
+++ b/src/dimscmd/commandOptions.nim
@@ -4,6 +4,7 @@ import strscans
 import common
 import macros
 import macroUtils
+import interactionUtils
 import utils
 {.experimental: "caseStmtMacros".}
 
@@ -36,7 +37,7 @@ proc toOptions*(parameters: seq[ProcParameter]): seq[ApplicationCommandOption] =
 
         var option = ApplicationCommandOption(
             kind: getCommandOption(parameter),
-            name: parameter.name,
+            name: parameter.name.normaliseParameterName(),
             description: description,
             required: some (not parameter.optional)
         )
@@ -87,7 +88,7 @@ proc toApplicationCommand*(group: CommandGroup): ApplicationCommand =
         result = ApplicationCommand(
             name: group.name,
             kind: atSlash,
-            description: group.name & " group", 
+            description: group.name & " group",
             defaultPermission: true)
         for child in group.children:
             result.options &= child.toOption()

--- a/tests/testCommands.nim
+++ b/tests/testCommands.nim
@@ -151,7 +151,7 @@ cmd.addChat("nimsyntax") do (a, b, c: int, s: string):
 
 template sendMsg(msg: string, prefix: untyped = "!!") =
     var message = Message(content: prefix & msg, guildID: some "479193574341214208")
-    check waitFor cmd.handleMessage(prefix, message)
+    check await cmd.handleMessage(prefix, message)
 
 template checkLatest(msg: string) =
     ## Checks if the latest message against `msg` and then clears it
@@ -176,11 +176,11 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
 
     test "Multiple prefixes":
         var message = Message(content: "!!ping")
-        check waitFor cmd.handleMessage(@["!!", "$"], message)
+        check await cmd.handleMessage(@["!!", "$"], message)
         check latestMessage == "pong"
 
         message = Message(content: "$ping")
-        check waitFor cmd.handleMessage(@["!!", "$"], message)
+        check await cmd.handleMessage(@["!!", "$"], message)
         check latestMessage == "pong"
 
     suite "Parsing parameters":
@@ -206,7 +206,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
 
         test "User Mentions":
           sendMsg("usernames <@!742010764302221334> <@!259999449995018240>")
-          check latestMessage == "Kayne amadan "
+          check latestMessage == "Kayne intellij_gamer "
 
         test "Role mention":
             sendMsg("role <@&483606693180342272>")
@@ -262,7 +262,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
 
         test "Calling command that doesn't exist":
             var message = Message(content: "!!calc divide 12 4", guildID: some "479193574341214208")
-            check not waitFor cmd.handleMessage("!!", message)
+            check not await cmd.handleMessage("!!", message)
 
         test "Higher depth than 1":
             sendMsg("say english greeting")
@@ -305,7 +305,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
         # test "Basic array":
             # sendMsg("array i am bob hello world")
             # check latestMessage == "i am boob hello"
-# 
+#
         # test "Variable array":
             # sendMsg("variablearray 1 2")
             # check latestMessage == "3"

--- a/tests/testScanning.nim
+++ b/tests/testScanning.nim
@@ -129,7 +129,7 @@ suite "Range types":
     test "Out of range":
         expect ScannerError:
             check scanner.next(range[2..5]) == 10
-        
+
 
 suite "Sequence scanning discord types":
     # I shouldn't test both individual seqs and group seqs at the same time but I'm lazy
@@ -151,7 +151,7 @@ suite "Sequence scanning discord types":
         let users = waitFor scanner.next(Future[seq[User]])
         check:
             users[0].username == "Kayne"
-            users[1].username == "amadan"
+            users[1].username == "intellij_gamer"
 
     test "Roles":
         let roles = waitFor scanner.next(Future[seq[Role]])

--- a/tests/testSlash.nim
+++ b/tests/testSlash.nim
@@ -10,6 +10,7 @@ import std/options
 import std/exitprocs
 import std/json
 import std/tables
+
 #
 # Test commands
 #
@@ -194,7 +195,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
             sendInteraction("user", %* [
               newParam("user", "259999449995018240", acotUser)
             ])
-            check latestMessage == "amadan"
+            check latestMessage == "intellij_gamer"
 
         test "Channel":
             sendInteraction("chan", %* [
@@ -214,7 +215,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
             sendInteraction("userq", %* [
               newParam("user", "259999449995018240", acotUser)
             ])
-            check latestMessage == "The user is amadan"
+            check latestMessage == "The user is intellij_gamer"
 
     proc newAddCommand(a, b: int, child = "add"): Interaction =
       ## Creates a new `calc add` command


### PR DESCRIPTION
Discord doesn't allow parameters to have capital letters so camelCase parameters break it. This gets around that by making all the names lowercase, and adding an underscore at the start if it starts with a capital letter (So it is still style sensitive.

Will probably also add some checks to make sure no special characters are in the parameter name.

Currently not merging since the tests seem to run into a memory leak somehow (The tests relating to slash commands are still passing so it should be fine to use this branch if you need this fix)