### PR TITLE
Fix default permission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: Tests
 
 on: [push, pull_request]
-  
+
 
 jobs:
   test:
@@ -10,11 +10,10 @@ jobs:
     strategy:
       matrix:
         nim: ['1.6.0', 'stable', 'devel' ]
-        gc: ['refc', 'orc']
       fail-fast: false
       max-parallel: 1
 
-    name: Nim ${{ matrix.nim }} ${{ matrix.gc }}
+    name: Nim ${{ matrix.nim }}
     steps:
     - name: Cache choosenim
       id: cache-choosenim
@@ -22,7 +21,7 @@ jobs:
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-${{ matrix.nim }}-${{ hashFiles('dimscmd.nimble') }}
-        
+
     - name: Setup Nim Enviroment
       uses: actions/checkout@master
     - uses: jiro4989/setup-nim-action@v1
@@ -34,7 +33,7 @@ jobs:
     - name: Run Tests
       env:
         DISCORDTOKEN: ${{ secrets.DISCORDTOKEN }}
-      run: nimble --deepcopy:on --gc:${{ matrix.gc }} test
+      run: nimble --deepcopy:on test
 
     - name: Check doc examples
-      run: nimble doc --deepcopy:on --threads:off --gc:${{ matrix.gc }} --project src/dimscmd.nim
+      run: nimble doc --deepcopy:on --threads:off --project src/dimscmd.nim

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 
 jobs:

--- a/src/dimscmd/commandOptions.nim
+++ b/src/dimscmd/commandOptions.nim
@@ -51,6 +51,8 @@ proc toApplicationCommand*(command: Command): ApplicationCommand {.inline.} =
         description: command.description,
         options: command.parameters.toOptions()
     )
+    when ApplicationCommand.defaultPermission is bool:
+      result.defaultPermission = true
 
 proc toOption(group: CommandGroup): ApplicationCommandOption =
     ## Recursively goes through a command group to generate the

--- a/src/dimscmd/commandOptions.nim
+++ b/src/dimscmd/commandOptions.nim
@@ -49,8 +49,7 @@ proc toApplicationCommand*(command: Command): ApplicationCommand {.inline.} =
     result = ApplicationCommand(
         name: command.name.leafName(),
         description: command.description,
-        options: command.parameters.toOptions(),
-        defaultPermission: true
+        options: command.parameters.toOptions()
     )
 
 proc toOption(group: CommandGroup): ApplicationCommandOption =

--- a/src/dimscmd/interactionUtils.nim
+++ b/src/dimscmd/interactionUtils.nim
@@ -81,6 +81,7 @@ template getOption(
         prop: untyped): Option[kind] {.dirty.} =
     bind hasKey
     bind `[]`
+    bind normaliseParameterName
     block:
       let mangledKey = normaliseParameterName(key)
       if opts.hasKey(mangledKey):


### PR DESCRIPTION
Dimscord now has `defaultPermission` be an `Option[bool]`. Since it is getting deprecated soon anyways (and defaults to true) we can safely just ignore it

I've also decreased the CI tests since we don't need to check both if we are testing with devel