### PR TITLE
Slash parameters correctly keep `seq[T]`

### DIFF
--- a/src/dimscmd.nim
+++ b/src/dimscmd.nim
@@ -134,10 +134,14 @@ proc addInteractionParameterParseCode(prc: NimNode, name: string, parameters: se
 
     for parameter in parameters:
         let ident = parameter.name.ident()
+        var kind = parameter.kind.ident()
+        if parameter.sequence:
+          kind = nnkBracketExpr.newTree("seq".ident(), kind)
+
         var procCall = nnkCall.newTree(
             "get".bindSym(brOpen),
             scannerIdent,
-            parameter.kind.ident(),
+            kind,
             parameter.name.newStrLitNode()
         )
         if parameter.future:

--- a/src/dimscmd/scanner.nim
+++ b/src/dimscmd/scanner.nim
@@ -21,10 +21,7 @@ type
 template raiseScannerError*(msg: string) =
     ## Raises a scanner error with the msg parameter being the `message` attribute attached to the exception.
     ## This is so that the async stack trace is not added to the exception message
-    var err: ref ScannerError
-    new err
-    err.message = msg
-    raise err
+    raise (ref ScannerError)(message: msg)
 
 macro scanProc*(prc: untyped): untyped =
     ## Adds in a type parameter to a proc to get a basic return type overloading
@@ -162,7 +159,7 @@ proc next*[T: enum](scanner: CommandScanner, kind: typedesc[T]): T =
 
 proc next*[T: range](scanner: CommandScanner, kind: typedesc[T]): T =
     ## Gets the next int value in a range
-    const 
+    const
         max = high T
         min = low T
     let value = scanner.next(int)
@@ -170,7 +167,7 @@ proc next*[T: range](scanner: CommandScanner, kind: typedesc[T]): T =
         result = value
     else:
         raiseScannerError(fmt"value is not in range {min}..{max}")
-        
+
 proc next*(scanner: CommandScanner): string {.scanProc.}=
     ## Returns the next word that appears in the command scanner
     scanner.skipWhitespace()

--- a/tests/testCommands.nim
+++ b/tests/testCommands.nim
@@ -150,7 +150,11 @@ cmd.addChat("nimsyntax") do (a, b, c: int, s: string):
 
 
 template sendMsg(msg: string, prefix: untyped = "!!") =
-    var message = Message(content: prefix & msg, guildID: some "479193574341214208")
+    var message = Message(
+      content: prefix & msg,
+      guildID: some "479193574341214208",
+      channelID: "1156121173176885248"
+    )
     check await cmd.handleMessage(prefix, message)
 
 template checkLatest(msg: string) =
@@ -237,11 +241,9 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
             check latestMessage == "hello"
 
     test "ISSUE: Invalid channel response msg is greater than 2000 characters":
-        # Somehow the error message for this is 2257 characters long
-        # I shouldn't be anywhere near that
-        # Resolved, turns out async adds the stacktrace to the msg
-        expect RestError: # Don't expect an Assert error
-            sendMsg("chan <#1234>")
+        # Tests that the async traceback isn't included in the message
+        # which causes it to go over the word limit
+        sendMsg("chan <#1234>")
 
     test "Custom type parsing":
         sendMsg("email test@example.com")

--- a/tests/testCommands.nim
+++ b/tests/testCommands.nim
@@ -149,13 +149,13 @@ cmd.addChat("nimsyntax") do (a, b, c: int, s: string):
     latestMessage = s & " " & $(a + b + c)
 
 
-template sendMsg(msg: string, prefix: untyped = "!!") =
+template sendMsg(msg: string, prefix: untyped = "!!", status = true) =
     var message = Message(
       content: prefix & msg,
       guildID: some "479193574341214208",
       channelID: "1156121173176885248"
     )
-    check await cmd.handleMessage(prefix, message)
+    check cmd.handleMessage(prefix, message).await() == status
 
 template checkLatest(msg: string) =
     ## Checks if the latest message against `msg` and then clears it
@@ -243,7 +243,7 @@ proc onReady(s: Shard, r: Ready) {.event(discord).} =
     test "ISSUE: Invalid channel response msg is greater than 2000 characters":
         # Tests that the async traceback isn't included in the message
         # which causes it to go over the word limit
-        sendMsg("chan <#1234>")
+        sendMsg("chan <#1234>", status = false)
 
     test "Custom type parsing":
         sendMsg("email test@example.com")

--- a/tests/testSlash.nim
+++ b/tests/testSlash.nim
@@ -128,6 +128,16 @@ cmd.addSlash("cases") do (camelCase: int, snakeCase: int, PascalCase: int):
 
 cmd.addSlashAlias("calc add", ["calc plus", "calc addition"])
 
+# Stub so the `someSeq` test compiles
+proc get(scanner: InteractionScanner, kind: typedesc[seq[int]], key: string): Option[seq[int]] =
+  discard
+
+cmd.addSlash("someSeq") do (test: seq[int]):
+  ## Checks that `seq[T]` is correctly a `seq`.
+  ## This check happens at compile time
+  static:
+    assert typeof(test) is seq[int], $typeof(test)
+
 proc newParam[T](name: string, val: T, kind: ApplicationCommandOptionType): JsonNode =
   result = %* {"name": name, "value": %val, "kind": kind.ord}
 


### PR DESCRIPTION
More of a hack than a proper fix due to the design of the parameter system 😕 think a 2.0 might be in order to clean up some of the issues